### PR TITLE
Add basic auth to event store url

### DIFF
--- a/src/core/event-store/event-store.ts
+++ b/src/core/event-store/event-store.ts
@@ -8,7 +8,7 @@ import * as http from 'http';
 import { config } from '../../../config';
 
 const eventStoreHostUrl = config.EVENT_STORE_SETTINGS.protocol +
-  `://${config.EVENT_STORE_SETTINGS.hostname}:${config.EVENT_STORE_SETTINGS.httpPort}/streams/`;
+  `://${config.EVENT_STORE_SETTINGS.credentials.username}:${config.EVENT_STORE_SETTINGS.credentials.password}@${config.EVENT_STORE_SETTINGS.hostname}:${config.EVENT_STORE_SETTINGS.httpPort}/streams/`;
 
 /**
  * @class EventStore


### PR DESCRIPTION
In the example event store is secured by http basic auth. This commit changes event url to include the credentials which are read from the config.