### PR TITLE
Add insecure env variable as a default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     environment:
       - EVENTSTORE_RUN_PROJECTIONS=All
       - EVENTSTORE_START_STANDARD_PROJECTIONS=true
+      - EVENTSTORE_INSECURE=true
     networks:
       - backend
 


### PR DESCRIPTION
Without this environment set to true, I get the following error when running docker-compose:

```
eventstore_1                          | [    1, 1,17:44:24.987,ERR] A certificate is required unless insecure mode (--insecure) is set.
examples-nodejs-cqrs-es-swagger_eventstore_1 exited with code 0
```
And so http://localhost:2113/web/index.html#/dashboard was not available